### PR TITLE
Google authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ assets/**
 node_modules/
 bower_components/
 
+# Ignore secrets file
+.secrets.yml
+
 # Filenames should NOT have spaces
 * *
 

--- a/gramex.app.yaml
+++ b/gramex.app.yaml
@@ -1,0 +1,44 @@
+url:
+  chart_annotation-home:
+    pattern: /$YAMLURL/
+    handler: FileHandler
+    kwargs:
+      path: $YAMLPATH/index.html
+      # See https://learn.gramener.com/guide/auth/#authorization for auth rules
+      auth:
+        login_url: /$YAMLURL/google
+      template: true
+      headers:
+        # Templates may have user-specific content. Cache privately.
+        # Keep max-age small (in case we log out & log in as another user.)
+        Cache-Control: private, max-age=1
+    cache: {expiry: {duration: 1}}
+  chart_annotation/training-data:
+    pattern: /$YAMLURL/data
+    handler: FormHandler
+    kwargs:
+      url: $DB_URL
+      table: charts
+      id: chart_id
+      xsrf_cookies: false
+  chart_annotation/view-charts:
+    pattern: /$YAMLURL/chart/(.*)
+    handler: FunctionHandler
+    kwargs:
+      function: chart_annotation.view
+  chart_annotation/unique-chart-names:
+    pattern: /$YAMLURL/uniq
+    handler: FormHandler
+    kwargs:
+      url: $DB_URL
+      query: "SELECT DISTINCT(label) FROM charts"
+  chart_annotation/login/google:
+    pattern: /$YAMLURL/google   # Map this URL
+    handler: GoogleAuth         # to the GoogleAuth handler
+    kwargs:
+      key: $DISCOVER_GOOGLE_KEY            # Set your app key
+      secret: $DISCOVER_GOOGLE_SECRET      # Set your app secret
+
+  chart_annotation-logout:
+    pattern: /$YAMLURL/logout/
+    handler: LogoutHandler

--- a/gramex.app.yaml
+++ b/gramex.app.yaml
@@ -5,8 +5,10 @@ url:
     kwargs:
       path: $YAMLPATH/index.html
       # See https://learn.gramener.com/guide/auth/#authorization for auth rules
-      auth:
+      auth: &AUTHVARS
         login_url: /$YAMLURL/google
+        membership:
+          - {hd: [gramener.com]}
       template: true
       headers:
         # Templates may have user-specific content. Cache privately.
@@ -21,23 +23,29 @@ url:
       table: charts
       id: chart_id
       xsrf_cookies: false
+      auth: *AUTHVARS
   chart_annotation/view-charts:
     pattern: /$YAMLURL/chart/(.*)
     handler: FunctionHandler
     kwargs:
       function: chart_annotation.view
+      auth: *AUTHVARS
   chart_annotation/unique-chart-names:
     pattern: /$YAMLURL/uniq
     handler: FormHandler
     kwargs:
       url: $DB_URL
       query: "SELECT DISTINCT(label) FROM charts"
+      auth: *AUTHVARS
   chart_annotation/login/google:
     pattern: /$YAMLURL/google   # Map this URL
     handler: GoogleAuth         # to the GoogleAuth handler
     kwargs:
       key: $DISCOVER_GOOGLE_KEY            # Set your app key
       secret: $DISCOVER_GOOGLE_SECRET      # Set your app secret
+      redirect:                     # Under the redirect section,
+        query: next
+        url: /$YAMLURL/
 
   chart_annotation-logout:
     pattern: /$YAMLURL/logout/

--- a/gramex.yaml
+++ b/gramex.yaml
@@ -6,60 +6,12 @@
 variables:
   DB_URL: sqlite:///$YAMLPATH/charts.db
 
-url:
-  chart_annotation-home:
-    pattern: /$YAMLURL/
-    handler: FileHandler
-    kwargs:
-      path: $YAMLPATH/index.html
-      # See https://learn.gramener.com/guide/auth/#authorization for auth rules
-      auth:
-        login_url: /$YAMLURL/login/
-      template: true
-      headers:
-        # Templates may have user-specific content. Cache privately.
-        # Keep max-age small (in case we log out & log in as another user.)
-        Cache-Control: private, max-age=1
-    cache: {expiry: {duration: 1}}
-  training-data:
-    pattern: /$YAMLURL/data
-    handler: FormHandler
-    kwargs:
-      url: $DB_URL
-      table: charts
-      id: chart_id
-      xsrf_cookies: false
-  view-charts:
-    pattern: /$YAMLURL/chart/(.*)
-    handler: FunctionHandler
-    kwargs:
-      function: chart_annotation.view
-  unique-chart-names:
-    pattern: /$YAMLURL/uniq
-    handler: FormHandler
-    kwargs:
-      url: $DB_URL
-      query: "SELECT DISTINCT(label) FROM charts"
-  chart_annotation-login:
-    pattern: /$YAMLURL/login/
-    # You MUST change the auth before deploying. DBAuth is commonly used.
-    # See https://learn.gramener.com/guide/auth/#database-auth
-    handler: SimpleAuth
-    kwargs:
-      template: $YAMLPATH/login.html
-      credentials:
-        alpha: alpha
-        beta: beta
-
-  chart_annotation-logout:
-    pattern: /$YAMLURL/logout/
-    handler: LogoutHandler
-
 # Notify testers what user ID and password to use
 test:
   auth:
-    user: alpha
-    password: alpha
+    user: '*@gramener.com'
+    password: (google)
+    login_url: /$YAMLURL/google
 
 
 # Gramex init configurations for app: chart_annotation
@@ -69,6 +21,7 @@ import:
   # replace 'YOUR-PROD-SERVER-NAME' with your production server host name.
   deploy if socket.gethostname() in {'YOUR-PROD-SERVER-NAME'}: $GRAMEXPATH/deploy.yaml
   # For alternate methods, see https://learn.gramener.com/guide/config/#conditions
+  secret: $YAMLPATH/.secrets.yml
 
   # /ui/ has Gramex UI components -- use this like the node_modules/ directory
   ui:
@@ -88,7 +41,7 @@ import:
     ADMIN_AUTH:
       membership:
         hd: gramener.com                    # Only @gramener.com Google Auth are admins
-
+  app: $YAMLPATH/gramex.app.yaml
 
 handlers:
   BaseHandler:


### PR DESCRIPTION
- Replaces `SimpleAuth` with `GoogleAuth`
- uses credentials from `.secrets.yml`, not part of the repository
- split portion of `gramex.yaml` into `gramex.app.yaml`

Post this, we could add email as an additional field in the database table.
